### PR TITLE
Fix origin and scaling of meshes, and fix type piracy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Meshing"); Pkg.test("Meshing"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Meshing")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+  - julia -e 'cd(Pkg.dir("Meshing")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - julia -e 'cd(Pkg.dir("Meshing")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Meshing"); Pkg.test("Meshing"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Meshing")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
   - julia -e 'cd(Pkg.dir("Meshing")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/src/Meshing.jl
+++ b/src/Meshing.jl
@@ -4,9 +4,13 @@ module Meshing
 
 using GeometryTypes
 
+abstract type AbstractMeshingAlgorithm end
+
 include("marching_tetrahedra.jl")
 include("marching_cubes.jl")
 
-export marching_cubes
+export marching_cubes,
+       MarchingCubes,
+       MarchingTetrahedra
 
 end # module

--- a/src/marching_cubes.jl
+++ b/src/marching_cubes.jl
@@ -412,6 +412,6 @@ end
 
 MarchingCubes(iso::T1=0.0, eps::T2=1e-3) where {T1, T2} = MarchingCubes{promote_type(T1, T2)}(iso, eps)
 
-function (::Type{MT})(df::SignedDistanceField, method::MarchingCubes) where {MT <: AbstractMesh}
+function (::Type{MT})(df::SignedDistanceField, method::MarchingCubes)::MT where {MT <: AbstractMesh}
      marching_cubes(df, method.iso, MT, method.eps)
 end

--- a/src/marching_cubes.jl
+++ b/src/marching_cubes.jl
@@ -287,12 +287,17 @@ However it may generate non-manifold meshes, while Marching
 Tetrahedra guarentees a manifold mesh.
 """
 function marching_cubes(sdf::SignedDistanceField{3,ST,FT},
-        iso=0.0,
-        MT::Type{M}=SimpleMesh{Point{3,Float64},Face{3,Int}}) where {ST,FT,M<:AbstractMesh}
+                               iso=0.0,
+                               MT::Type{M}=SimpleMesh{Point{3,Float64},Face{3,Int}},
+                               eps=0.00001) where {ST,FT,M<:AbstractMesh}
     nx, ny, nz = size(sdf)
     h = HyperRectangle(sdf)
     w = widths(h)
-    s = Point{3,Float64}(w[1]/nx, w[2]/ny, w[3]/nz)
+    orig = origin(HyperRectangle(sdf))
+
+    # we subtract one from the length along each axis because
+    # an NxNxN SDF has N-1 cells on each axis
+    s = Point{3,Float64}(w[1]/(nx-1), w[2]/(ny-1), w[3]/(nz-1))
 
     # arrays for vertices and faces
     vts = Point{3,Float64}[]
@@ -315,63 +320,63 @@ function marching_cubes(sdf::SignedDistanceField{3,ST,FT},
         # Cube is entirely in/out of the surface
         edge_table[cubeindex] == 0 && continue
 
-        points = (Point{3,Float64}(xi-1,yi-1,zi-1).*s,
-                  Point{3,Float64}(xi,yi-1,zi-1).*s,
-                  Point{3,Float64}(xi,yi,zi-1).*s,
-                  Point{3,Float64}(xi-1,yi,zi-1).*s,
-                  Point{3,Float64}(xi-1,yi-1,zi).*s,
-                  Point{3,Float64}(xi,yi-1,zi).*s,
-                  Point{3,Float64}(xi,yi,zi).*s,
-                  Point{3,Float64}(xi-1,yi,zi).*s)
+        points = (Point{3,Float64}(xi-1,yi-1,zi-1) .* s .+ orig,
+                  Point{3,Float64}(xi,yi-1,zi-1) .* s .+ orig,
+                  Point{3,Float64}(xi,yi,zi-1) .* s .+ orig,
+                  Point{3,Float64}(xi-1,yi,zi-1) .* s .+ orig,
+                  Point{3,Float64}(xi-1,yi-1,zi) .* s .+ orig,
+                  Point{3,Float64}(xi,yi-1,zi) .* s .+ orig,
+                  Point{3,Float64}(xi,yi,zi) .* s .+ orig,
+                  Point{3,Float64}(xi-1,yi,zi) .* s .+ orig)
 
         # Find the vertices where the surface intersects the cube
         if (edge_table[cubeindex] & 1 != 0)
           vertlist[1] =
-             vertex_interp(iso,points[1],points[2],sdf[xi,yi,zi],sdf[xi+1,yi,zi])
+             vertex_interp(iso,points[1],points[2],sdf[xi,yi,zi],sdf[xi+1,yi,zi], eps)
         end
         if (edge_table[cubeindex] & 2 != 0)
           vertlist[2] =
-             vertex_interp(iso,points[2],points[3],sdf[xi+1,yi,zi],sdf[xi+1,yi+1,zi])
+             vertex_interp(iso,points[2],points[3],sdf[xi+1,yi,zi],sdf[xi+1,yi+1,zi], eps)
         end
         if (edge_table[cubeindex] & 4 != 0)
           vertlist[3] =
-             vertex_interp(iso,points[3],points[4],sdf[xi+1,yi+1,zi],sdf[xi,yi+1,zi])
+             vertex_interp(iso,points[3],points[4],sdf[xi+1,yi+1,zi],sdf[xi,yi+1,zi], eps)
         end
         if (edge_table[cubeindex] & 8 != 0)
           vertlist[4] =
-             vertex_interp(iso,points[4],points[1],sdf[xi,yi+1,zi],sdf[xi,yi,zi])
+             vertex_interp(iso,points[4],points[1],sdf[xi,yi+1,zi],sdf[xi,yi,zi], eps)
         end
         if (edge_table[cubeindex] & 16 != 0)
           vertlist[5] =
-             vertex_interp(iso,points[5],points[6],sdf[xi,yi,zi+1],sdf[xi+1,yi,zi+1])
+             vertex_interp(iso,points[5],points[6],sdf[xi,yi,zi+1],sdf[xi+1,yi,zi+1], eps)
         end
         if (edge_table[cubeindex] & 32 != 0)
           vertlist[6] =
-             vertex_interp(iso,points[6],points[7],sdf[xi+1,yi,zi+1],sdf[xi+1,yi+1,zi+1])
+             vertex_interp(iso,points[6],points[7],sdf[xi+1,yi,zi+1],sdf[xi+1,yi+1,zi+1], eps)
         end
         if (edge_table[cubeindex] & 64 != 0)
           vertlist[7] =
-             vertex_interp(iso,points[7],points[8],sdf[xi+1,yi+1,zi+1],sdf[xi,yi+1,zi+1])
+             vertex_interp(iso,points[7],points[8],sdf[xi+1,yi+1,zi+1],sdf[xi,yi+1,zi+1], eps)
         end
         if (edge_table[cubeindex] & 128 != 0)
           vertlist[8] =
-             vertex_interp(iso,points[8],points[5],sdf[xi,yi+1,zi+1],sdf[xi,yi,zi+1])
+             vertex_interp(iso,points[8],points[5],sdf[xi,yi+1,zi+1],sdf[xi,yi,zi+1], eps)
         end
         if (edge_table[cubeindex] & 256 != 0)
           vertlist[9] =
-             vertex_interp(iso,points[1],points[5],sdf[xi,yi,zi],sdf[xi,yi,zi+1])
+             vertex_interp(iso,points[1],points[5],sdf[xi,yi,zi],sdf[xi,yi,zi+1], eps)
         end
         if (edge_table[cubeindex] & 512 != 0)
           vertlist[10] =
-             vertex_interp(iso,points[2],points[6],sdf[xi+1,yi,zi],sdf[xi+1,yi,zi+1])
+             vertex_interp(iso,points[2],points[6],sdf[xi+1,yi,zi],sdf[xi+1,yi,zi+1], eps)
         end
         if (edge_table[cubeindex] & 1024 != 0)
           vertlist[11] =
-             vertex_interp(iso,points[3],points[7],sdf[xi+1,yi+1,zi],sdf[xi+1,yi+1,zi+1])
+             vertex_interp(iso,points[3],points[7],sdf[xi+1,yi+1,zi],sdf[xi+1,yi+1,zi+1], eps)
         end
         if (edge_table[cubeindex] & 2048 != 0)
           vertlist[12] =
-             vertex_interp(iso,points[4],points[8],sdf[xi,yi+1,zi],sdf[xi,yi+1,zi+1])
+             vertex_interp(iso,points[4],points[8],sdf[xi,yi+1,zi],sdf[xi,yi+1,zi+1], eps)
         end
 
         # Create the triangle
@@ -398,4 +403,15 @@ function vertex_interp(iso, p1, p2, valp1, valp2, eps = 0.00001)
     p = p1 + mu * (p2 - p1)
 
     return p
+end
+
+struct MarchingCubes{T} <: AbstractMeshingAlgorithm
+     iso::T
+     eps::T
+end
+
+MarchingCubes(iso::T1=0.0, eps::T2=1e-3) where {T1, T2} = MarchingCubes{promote_type(T1, T2)}(iso, eps)
+
+function (::Type{MT})(df::SignedDistanceField, method::MarchingCubes) where {MT <: AbstractMesh}
+     marching_cubes(df, method.iso, MT, method.eps)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,46 +2,95 @@ using Meshing
 using Base.Test
 using GeometryTypes
 
-# Produce a level set function that is a noisy version of the distance from
-# the origin (such that level sets are noisy spheres).
-#
-# The noise should exercise marching tetrahedra's ability to produce a water-
-# tight surface in all cases (unlike standard marching cubes).
-#
-N = 10
-sigma = 1.0
-distance = Float32[ sqrt(Float32(i*i+j*j+k*k)) for i = -N:N, j = -N:N, k = -N:N ]
-distance = distance + sigma*rand(2*N+1,2*N+1,2*N+1)
 
-# Extract an isosurface.
-#
-lambda = N-2*sigma # isovalue
+@testset "meshing" begin
+    @testset "noisy spheres" begin
+        # Produce a level set function that is a noisy version of the distance from
+        # the origin (such that level sets are noisy spheres).
+        #
+        # The noise should exercise marching tetrahedra's ability to produce a water-
+        # tight surface in all cases (unlike standard marching cubes).
+        #
+        N = 10
+        sigma = 1.0
+        distance = Float32[ sqrt(Float32(i*i+j*j+k*k)) for i = -N:N, j = -N:N, k = -N:N ]
+        distance = distance + sigma*rand(2*N+1,2*N+1,2*N+1)
 
-msh = HomogenousMesh(distance,lambda)
+        # Extract an isosurface.
+        #
+        lambda = N-2*sigma # isovalue
 
-s2 = SignedDistanceField(HyperRectangle(Vec(0,0,0.),Vec(1,1,1.))) do v
-    sqrt(sum(dot(v,v))) - 1 # sphere
+        msh = HomogenousMesh(distance, MarchingTetrahedra(lambda))
+
+        s2 = SignedDistanceField(HyperRectangle(Vec(0,0,0.),Vec(1,1,1.))) do v
+            sqrt(sum(dot(v,v))) - 1 # sphere
+        end
+
+        msh = HomogenousMesh(s2, MarchingTetrahedra())
+        @test length(vertices(msh)) == 973
+        @test length(faces(msh)) == 1830
+    end
+
+    @testset "vertex interpolation" begin
+        @test Meshing.vertex_interp(0, Vec(0,0,0), Vec(0,1,0), -1, 1) == Vec(0,0.5,0)
+        @test Meshing.vertex_interp(-1, Vec(0,0,0), Vec(0,1,0), -1, 1) == Vec(0,0,0)
+        @test Meshing.vertex_interp(1, Vec(0,0,0), Vec(0,1,0), -1, 1) == Vec(0,1,0)
+    end
+
+    @testset "marching cubes" begin
+        sdf = SignedDistanceField(HyperRectangle(Vec(-1,-1,-1.),Vec(2,2,2.))) do v
+            sqrt(sum(dot(v,v))) - 1 # sphere
+        end
+
+        m = marching_cubes(sdf,0)
+        m2 = marching_cubes(sdf)
+        @test length(vertices(m)) == 10968
+        @test length(faces(m)) == 3656
+        @test m == m2
+
+    end
+    @testset "respect origin" begin
+        # verify that when we construct a mesh, that mesh:
+        #   a) respects the origin of the SDF
+        #   b) is correctly spaced so that symmetric functions create symmetric meshes
+        f = x -> norm(x)
+        bounds = HyperRectangle(Vec(-1, -1, -1), Vec(2, 2, 2))
+        resolution = 0.1
+        sdf = SignedDistanceField(f, bounds, resolution)
+
+        for algorithm in (MarchingCubes(0.5), MarchingTetrahedra(0.5))
+            mesh = GLNormalMesh(sdf, algorithm)
+            # should be centered on the origin
+            @test mean(vertices(mesh)) ≈ [0, 0, 0] atol=0.15*resolution
+            # and should be symmetric about the origin
+            @test maximum(vertices(mesh)) ≈ [0.5, 0.5, 0.5]
+            @test minimum(vertices(mesh)) ≈ [-0.5, -0.5, -0.5]
+        end
+    end
+
+    @testset "AbstractMeshingAlgorithm interface" begin
+        f = x -> norm(x) - 0.5
+        bounds = HyperRectangle(Vec(-1, -1, -1), Vec(2, 2, 2))
+        resolution = 0.1
+        sdf = SignedDistanceField(f, bounds, resolution)
+
+        @testset "marching cubes" begin
+            m1 = @test_nowarn marching_cubes(sdf, 0.0, GLNormalMesh)
+            m2 = @test_nowarn GLNormalMesh(sdf, MarchingCubes())
+            @test vertices(m1) == vertices(m2)
+            @test faces(m1) == faces(m2)
+        end
+
+        @testset "marching tetrahedra" begin
+            m1 = @test_warn "is deprecated" GLNormalMesh(sdf)
+            m2 = @test_warn "is deprecated" GLNormalMesh(sdf, 1e-3)
+            m3 = @test_nowarn GLNormalMesh(sdf, MarchingTetrahedra())
+            @test vertices(m1) == vertices(m2) == vertices(m3)
+            @test faces(m1) == faces(m2) == faces(m3)
+        end
+    end
 end
 
-msh = HomogenousMesh(s2)
-@test length(vertices(msh)) == 973
-@test length(faces(msh)) == 1830
-
-# Vertex interpolation
-@test Meshing.vertex_interp(0, Vec(0,0,0), Vec(0,1,0), -1, 1) == Vec(0,0.5,0)
-@test Meshing.vertex_interp(-1, Vec(0,0,0), Vec(0,1,0), -1, 1) == Vec(0,0,0)
-@test Meshing.vertex_interp(1, Vec(0,0,0), Vec(0,1,0), -1, 1) == Vec(0,1,0)
-
-# marching cubes
-sdf = SignedDistanceField(HyperRectangle(Vec(-1,-1,-1.),Vec(2,2,2.))) do v
-    sqrt(sum(dot(v,v))) - 1 # sphere
-end
-
-m = marching_cubes(sdf,0)
-m2 = marching_cubes(sdf)
-@test length(vertices(m)) == 10968
-@test length(faces(m)) == 3656
-@test m == m2
 
 if "--profile" in ARGS
     HomogenousMesh(s2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,7 @@ using GeometryTypes
         sdf = SignedDistanceField(f, bounds, resolution)
 
         for algorithm in (MarchingCubes(0.5), MarchingTetrahedra(0.5))
-            mesh = GLNormalMesh(sdf, algorithm)
+            mesh = @inferred GLNormalMesh(sdf, algorithm)
             # should be centered on the origin
             @test mean(vertices(mesh)) ≈ [0, 0, 0] atol=0.15*resolution
             # and should be symmetric about the origin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,11 @@ using GeometryTypes
             m3 = @test_nowarn GLNormalMesh(sdf, MarchingTetrahedra())
             @test vertices(m1) == vertices(m2) == vertices(m3)
             @test faces(m1) == faces(m2) == faces(m3)
+
+            m4 = @test_warn "is deprecated" GLNormalMesh(sdf.data, 0.5)
+            m5 = @test_nowarn GLNormalMesh(sdf.data, MarchingTetrahedra(0.5))
+            @test vertices(m4) == vertices(m5)
+            @test faces(m4) == faces(m5)
         end
     end
 end


### PR DESCRIPTION
There are a few things included here. Please let me know if there are any concerns, issues, questions, etc. 

### Mesh origins and scaling

* `marching_cubes` and `marchingTetrahedra` both ignored the origin of the signed distance field, which is now fixed.
* `marchingTetrahedra` also ignored the scaling of the SDF points, and just returned points as if the SDF was over a rectangle from `1:size(sdf)`, also fixed
* `marching_cubes` didn't ignore the scaling of the SDF points, but its vertices were slightly off because it computed the spacing as `widths(sdf) ./ size(sdf)` when it really should be `widths(sdf) ./ (size(sdf) .- 1)` because a cube with N samples per side has N-1 cells per side. That's also fixed.

Fixes #6 
Fixes https://github.com/JuliaGeometry/GeometryTypes.jl/issues/49

### Type piracy

Currently, the way marching tetrahedra is implemented is type piracy: we create a new method for `(::AbstractMesh)(::SignedDistanceField, ::Real)`, but none of those types are owned by this package. It's also a bit confusing, because it makes it unclear which algorithm will be used. 

To fix this, I'm deprecating that constructor and instead introducing two new types: `
MarchingCubes <: AbstractMeshingAlgorithm` and `MarchingTetrahedra <: AbstractMeshingAlgorithm`.  These two types make it clear which algorithm is being used, and they can also store the relevant parameters (iso value and epsilon). Usage is now:

```julia
m1 = HomogeneousMesh(sdf, MarchingCubes())
m2 = HomogeneousMesh(sdf, MarchingTetrahedra())
```

to choose an iso value or epsilon, just do:

```julia
HomogenousMesh(sdf, MarchingCubes(iso_value, epsilon))
```

### More tests

I've added some tests to ensure that the origin and offset issues with the mesh vertices stay fixed. 

