### PR TITLE
relax typing in marchingTetrahedra so that isovalue can be a different type

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+ForwardDiff 0.7


### PR DESCRIPTION
Fixes #9 . And, as a bonus, the isovalue and eps parameters can now be *any* subtype of Real, independent of the sampled data. This means we can now do fun things like differentiate the entire marching tetrahedra algorithm just by using ForwardDiff.jl. I've added a test showing how you'd go about doing that. 

Performance is unchanged on Float64 inputs. 