### PR TITLE
First Pass of performance improvements to Marching Tetrahedra

### DIFF
--- a/src/lut/mt.jl
+++ b/src/lut/mt.jl
@@ -27,7 +27,7 @@ struct VoxelIndices{T <: Integer}
     voxEdgeIx::NTuple{8,NTuple{8,T}}
     subTets::NTuple{6,NTuple{4,T}}
     tetEdgeCrnrs::NTuple{6,NTuple{2,T}}
-    tetTri::NTuple{16,NTuple{6,T}}
+    tetTri::NTuple{14,NTuple{6,T}}
 
     function VoxelIndices{T}() where {T <: Integer}
         voxCrnrPos = ((0, 0, 0),
@@ -91,8 +91,7 @@ struct VoxelIndices{T <: Integer}
                         (3,4))
 
         # triangle cases for a given tetrahedron edge code
-        tetTri = ((0,0,0,0,0,0),
-                    (1,3,4,0,0,0),
+        tetTri = ((1,3,4,0,0,0),
                     (1,5,2,0,0,0),
                     (3,5,2,3,4,5),
                     (2,6,3,0,0,0),
@@ -105,8 +104,7 @@ struct VoxelIndices{T <: Integer}
                     (2,3,6,0,0,0),
                     (3,2,5,3,5,4),
                     (1,2,5,0,0,0),
-                    (1,4,3,0,0,0),
-                    (0,0,0,0,0,0))
+                    (1,4,3,0,0,0))
 
         new{T}(voxCrnrPos,
             voxEdgeCrnrs,

--- a/src/lut/mt.jl
+++ b/src/lut/mt.jl
@@ -21,7 +21,7 @@ Voxel corner and edge indexing conventions
  X
 """
 struct VoxelIndices{T <: Integer}
-    voxCrnrPos::NTuple{8,NTuple{3,T}}
+    voxCrnrPos::NTuple{8,Point{3,T}}
     voxEdgeCrnrs::NTuple{19, NTuple{2,T}}
     voxEdgeDir::NTuple{19,T}
     voxEdgeIx::NTuple{8,NTuple{8,T}}
@@ -30,14 +30,14 @@ struct VoxelIndices{T <: Integer}
     tetTri::NTuple{14,NTuple{6,T}}
 
     function VoxelIndices{T}() where {T <: Integer}
-        voxCrnrPos = ((0, 0, 0),
-                      (0, 1, 0),
-                      (1, 1, 0),
-                      (1, 0, 0),
-                      (0, 0, 1),
-                      (0, 1, 1),
-                      (1, 1, 1),
-                      (1, 0, 1))
+        voxCrnrPos = (Point(0, 0, 0),
+                      Point(0, 1, 0),
+                      Point(1, 1, 0),
+                      Point(1, 0, 0),
+                      Point(0, 0, 1),
+                      Point(0, 1, 1),
+                      Point(1, 1, 1),
+                      Point(1, 0, 1))
         # the voxel IDs at either end of the tetrahedra edges, by edge ID
         voxEdgeCrnrs = ((1, 2),
                         (2, 3),

--- a/src/lut/mt.jl
+++ b/src/lut/mt.jl
@@ -20,98 +20,79 @@ Voxel corner and edge indexing conventions
   /
  X
 """
-struct VoxelIndices{T <: Integer}
-    voxCrnrPos::NTuple{8,Point{3,T}}
-    voxEdgeCrnrs::NTuple{19, NTuple{2,T}}
-    voxEdgeDir::NTuple{19,T}
-    voxEdgeIx::NTuple{8,NTuple{8,T}}
-    subTets::NTuple{6,NTuple{4,T}}
-    tetEdgeCrnrs::NTuple{6,NTuple{2,T}}
-    tetTri::NTuple{14,NTuple{6,T}}
 
-    function VoxelIndices{T}() where {T <: Integer}
-        voxCrnrPos = (Point(0, 0, 0),
-                      Point(0, 1, 0),
-                      Point(1, 1, 0),
-                      Point(1, 0, 0),
-                      Point(0, 0, 1),
-                      Point(0, 1, 1),
-                      Point(1, 1, 1),
-                      Point(1, 0, 1))
-        # the voxel IDs at either end of the tetrahedra edges, by edge ID
-        voxEdgeCrnrs = ((1, 2),
-                        (2, 3),
-                        (4, 3),
-                        (1, 4),
-                        (5, 6),
-                        (6, 7),
-                        (8, 7),
-                        (5, 8),
-                        (1, 5),
-                        (2, 6),
-                        (3, 7),
-                        (4, 8),
-                        (1, 3),
-                        (1, 8),
-                        (1, 6),
-                        (5, 7),
-                        (2, 7),
-                        (4, 7),
-                        (1, 7))
+const voxCrnrPos = (Point(0, 0, 0),
+                Point(0, 1, 0),
+                Point(1, 1, 0),
+                Point(1, 0, 0),
+                Point(0, 0, 1),
+                Point(0, 1, 1),
+                Point(1, 1, 1),
+                Point(1, 0, 1))
+# the voxel IDs at either end of the tetrahedra edges, by edge ID
+const voxEdgeCrnrs = ((1, 2),
+                (2, 3),
+                (4, 3),
+                (1, 4),
+                (5, 6),
+                (6, 7),
+                (8, 7),
+                (5, 8),
+                (1, 5),
+                (2, 6),
+                (3, 7),
+                (4, 8),
+                (1, 3),
+                (1, 8),
+                (1, 6),
+                (5, 7),
+                (2, 7),
+                (4, 7),
+                (1, 7))
 
-        # direction codes:
-        # 0 => +x, 1 => +y, 2 => +z,
-        # 3 => +xy, 4 => +xz, 5 => +yz, 6 => +xyz
-        voxEdgeDir = (1,0,1,0,1,0,1,0,2,2,2,2,3,4,5,3,4,5,6)
+# direction codes:
+# 0 => +x, 1 => +y, 2 => +z,
+# 3 => +xy, 4 => +xz, 5 => +yz, 6 => +xyz
+const voxEdgeDir = (1,0,1,0,1,0,1,0,2,2,2,2,3,4,5,3,4,5,6)
 
-        # For a pair of corner IDs, the edge ID joining them
-        # 0 denotes a pair with no edge
-        voxEdgeIx = ((0,1,13,4,9,15,19,14),
-                     (1,0,2,0,0,10,17,0),
-                     (13,2,0,3,0,0,11,0),
-                     (4,0,3,0,0,0,18,12),
-                     (9,0,0,0,0,5,16,8),
-                     (15,10,0,0,5,0,6,0),
-                     (19,17,11,18,16,6,0,7),
-                     (14,0,0,12,8,0,7,0))
+# For a pair of corner IDs, the edge ID joining them
+# 0 denotes a pair with no edge
+const voxEdgeIx = ((0,1,13,4,9,15,19,14),
+                (1,0,2,0,0,10,17,0),
+                (13,2,0,3,0,0,11,0),
+                (4,0,3,0,0,0,18,12),
+                (9,0,0,0,0,5,16,8),
+                (15,10,0,0,5,0,6,0),
+                (19,17,11,18,16,6,0,7),
+                (14,0,0,12,8,0,7,0))
 
-        # voxel corners that comprise each of the six tetrahedra
-        subTets = ((1,3,2,7),
-                      (1,8,4,7),
-                      (1,4,3,7),
-                      (1,2,6,7),
-                      (1,5,8,7),
-                      (1,6,5,7))
-        # tetrahedron corners for each edge (indices 1-4)
-        tetEdgeCrnrs = ((1,2),
-                        (2,3),
-                        (1,3),
-                        (1,4),
-                        (2,4),
-                        (3,4))
+# voxel corners that comprise each of the six tetrahedra
+const subTets = ((1,3,2,7),
+                (1,8,4,7),
+                (1,4,3,7),
+                (1,2,6,7),
+                (1,5,8,7),
+                (1,6,5,7))
+# tetrahedron corners for each edge (indices 1-4)
+const tetEdgeCrnrs = ((1,2),
+                (2,3),
+                (1,3),
+                (1,4),
+                (2,4),
+                (3,4))
 
-        # triangle cases for a given tetrahedron edge code
-        tetTri = ((1,3,4,0,0,0),
-                    (1,5,2,0,0,0),
-                    (3,5,2,3,4,5),
-                    (2,6,3,0,0,0),
-                    (1,6,4,1,2,6),
-                    (1,5,6,1,6,3),
-                    (4,5,6,0,0,0),
-                    (4,6,5,0,0,0),
-                    (1,6,5,1,3,6),
-                    (1,4,6,1,6,2),
-                    (2,3,6,0,0,0),
-                    (3,2,5,3,5,4),
-                    (1,2,5,0,0,0),
-                    (1,4,3,0,0,0))
-
-        new{T}(voxCrnrPos,
-            voxEdgeCrnrs,
-            voxEdgeDir,
-            voxEdgeIx,
-            subTets,
-            tetEdgeCrnrs,
-            tetTri)
-    end
-end
+# triangle cases for a given tetrahedron edge code
+const tetTri = ((1,3,4,0,0,0),
+            (1,5,2,0,0,0),
+            (3,5,2,3,4,5),
+            (2,6,3,0,0,0),
+            (1,6,4,1,2,6),
+            (1,5,6,1,6,3),
+            (4,5,6,0,0,0),
+            (4,6,5,0,0,0),
+            (1,6,5,1,3,6),
+            (1,4,6,1,6,2),
+            (2,3,6,0,0,0),
+            (3,2,5,3,5,4),
+            (1,2,5,0,0,0),
+            (1,4,3,0,0,0))

--- a/src/marching_tetrahedra.jl
+++ b/src/marching_tetrahedra.jl
@@ -45,17 +45,10 @@ corners (thereby preventing degeneracies).
     tgtVal  = vals[ixs[2]]
     a       = min(max((iso-srcVal)/(tgtVal-srcVal), eps), one(T)-eps)
     b       = one(T)-a
-    c1x,c1y,c1z = vxidx.voxCrnrPos[ixs[1]]
-    c2x,c2y,c2z = vxidx.voxCrnrPos[ixs[2]]
-    
-    #TODO SIMD These with broadcasting. This shoudl also fix the propogation when using
-    # forward diff
+    c1= vxidx.voxCrnrPos[ixs[1]]
+    c2 = vxidx.voxCrnrPos[ixs[2]]
 
-    Point(
-          x+b*c1x+a*c2x,
-          y+b*c1y+a*c2y,
-          z+b*c1z+a*c2z
-    )
+    Point{3,Float64}(x,y,z) + c1 .* b + c2.* a
 end
 
 """

--- a/src/marching_tetrahedra.jl
+++ b/src/marching_tetrahedra.jl
@@ -127,7 +127,7 @@ an approximate isosurface by the method of marching tetrahedra.
 function marchingTetrahedra(lsf::AbstractArray{T,3}, iso::Real, eps::Real, indextype::Type{IT}) where {T<:Real, IT <: Integer}
     vertex_eltype = promote_type(T, typeof(iso), typeof(eps))
     vts        = Dict{indextype, Point{3,vertex_eltype}}()
-    fcs        = Array{Face{3,indextype}}(undef, 0)
+    fcs        = Face{3,indextype}[]
     sizehint!(vts, div(length(lsf),8))
     sizehint!(fcs, div(length(lsf),4))
     vxidx = VoxelIndices{indextype}()
@@ -162,10 +162,14 @@ function isosurface(lsf, isoval, eps, indextype=Int, index_start=one(Int))
         vtD[x] = k
         k += one(indextype)
     end
-    fcAry = Face{3,indextype}[Face{3,indextype}(vtD[f[1]], vtD[f[2]], vtD[f[3]]) for f in fcs]
+    # rewrite the face array with the new vertex values
+    for i in eachindex(fcs)
+        f = fcs[i]
+        fcs[i] = Face{3, indextype}(vtD[f[1]], vtD[f[2]], vtD[f[3]])
+    end
     vtAry = collect(values(vts))
 
-    (vtAry, fcAry)
+    (vtAry, fcs)
 end
 
 isosurface(lsf,isoval) = isosurface(lsf,isoval, convert(eltype(lsf), 0.001))

--- a/src/marching_tetrahedra.jl
+++ b/src/marching_tetrahedra.jl
@@ -47,6 +47,9 @@ corners (thereby preventing degeneracies).
     b       = one(T)-a
     c1x,c1y,c1z = vxidx.voxCrnrPos[ixs[1]]
     c2x,c2y,c2z = vxidx.voxCrnrPos[ixs[2]]
+    
+    #TODO SIMD These with broadcasting. This shoudl also fix the propogation when using
+    # forward diff
 
     Point(
           x+b*c1x+a*c2x,
@@ -66,6 +69,7 @@ present.
                    eps::Real, vxidx::VoxelIndices{IType}) where {T <: Real, S <: Real, IType <: Integer}
 
     vId = vertId(e, x, y, z, nx, ny, vxidx)
+    # TODO we can probably immediately construct the vertex array here and use vert id to map to sequential ordering
     if !haskey(vts, vId)
         vts[vId] = vertPos(e, x, y, z, vals, iso, eps, vxidx)
     end

--- a/src/marching_tetrahedra.jl
+++ b/src/marching_tetrahedra.jl
@@ -25,7 +25,7 @@ regardless of which of its neighboring voxels is asking for it) in order
 for vertex sharing to be implemented properly.
 """
 function vertId(e::IType, x::IType, y::IType, z::IType,
-nx::IType, ny::IType, vxidx::VoxelIndices{IType}) where {IType <: Integer}
+                nx::IType, ny::IType, vxidx::VoxelIndices{IType}) where {IType <: Integer}
     @inbounds dx, dy, dz = vxidx.voxCrnrPos[vxidx.voxEdgeCrnrs[e][1]]
     vxidx.voxEdgeDir[e]+7*(x-1+dx+nx*(y-1+dy+ny*(z-1+dz)))
 end
@@ -37,7 +37,7 @@ eps represents the "bump" factor to keep vertices away from voxel
 corners (thereby preventing degeneracies).
 """
 function vertPos(e::IType, x::IType, y::IType, z::IType,
-vals::NTuple{8,T}, iso::Real, eps::Real, vxidx::VoxelIndices{IType}) where {T<:Real, IType <: Integer}
+                 vals::NTuple{8,T}, iso::Real, eps::Real, vxidx::VoxelIndices{IType}) where {T<:Real, IType <: Integer}
 
     @inbounds ixs     = vxidx.voxEdgeCrnrs[e]
     @inbounds srcVal  = vals[ixs[1]]
@@ -59,10 +59,10 @@ Gets the vertex ID, adding it to the vertex dictionary if not already
 present.
 """
 function getVertId(e::IType, x::IType, y::IType, z::IType,
- nx::IType, ny::IType,
- vals, iso::Real,
- vts::Dict{IType, Point{3,S}},
- eps::Real, vxidx::VoxelIndices{IType}) where {T <: Real, S <: Real, IType <: Integer}
+                   nx::IType, ny::IType,
+                   vals, iso::Real,
+                   vts::Dict{IType, Point{3,S}},
+                   eps::Real, vxidx::VoxelIndices{IType}) where {T <: Real, S <: Real, IType <: Integer}
 
     vId = vertId(e, x, y, z, nx, ny, vxidx)
     if !haskey(vts, vId)


### PR DESCRIPTION
Extracting my commits from my other branch to make merging and rebase easier.

before:
  "MarchingTetrahedra{Float64}" => BenchmarkTools.Trial: 
	  memory estimate:  17.53 MiB
	  allocs estimate:  445006
	  --------------
	  minimum time:     45.394 ms (0.00% GC)
	  median time:      47.722 ms (2.93% GC)
	  mean time:        58.909 ms (3.89% GC)
	  maximum time:     981.840 ms (9.03% GC)
	  --------------
	  samples:          85
	  evals/sample:     1

after:
  "MarchingTetrahedra{Float64}" => BenchmarkTools.Trial: 
	  memory estimate:  10.27 MiB
	  allocs estimate:  120396
	  --------------
	  minimum time:     11.393 ms (0.00% GC)
	  median time:      12.211 ms (0.00% GC)
	  mean time:        13.944 ms (3.29% GC)
	  maximum time:     531.305 ms (11.73% GC)
	  --------------
	  samples:          359
	  evals/sample:     1

I have identified other performance hotspots here that bring this under the 10ms mark: https://github.com/JuliaGeometry/Meshing.jl/tree/sjk/mt-fst2
But for the test cases to pass I need parts of the workingprecision branch.
