### PR TITLE
cleanup GB API and Makie viz by defaulting to GL primitives

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -24,7 +24,7 @@ algo = MarchingCubes(iso=100, insidepositive=true)
 # algo = NaiveSurfaceNets(iso=100, insidepositive=true)
 
 # generate the mesh using marching cubes
-mc = HomogenousMesh{Point{3,Float32},TriangleFace{Int}}(ctacardio, algo)
+mc = Mesh(ctacardio, algo)
 
 # we can call isosurface to get a vector of points and vector of faces indexing to the points
 # vertices, faces = isosurface(ctacardio, algo, Point{3,Float32}, TriangleFace{Int})
@@ -45,8 +45,9 @@ using GeometryBasics
 gyroid(v) = cos(v[1])*sin(v[2])+cos(v[2])*sin(v[3])+cos(v[3])*sin(v[1])
 gyroid_shell(v) = max(gyroid(v)-0.4,-gyroid(v)-0.4)
 
-# generate directly using GeometryBasics API, normals are computed by GeometryBasics
-gy_mesh = GLNormalMesh(gyroid_shell, Rect(Vec(0,0,0),Vec(pi*4,pi*4,pi*4)),
+# generate directly using GeometryBasics API
+# Rect specifies the sampling intervals
+gy_mesh = Mesh(gyroid_shell, Rect(Vec(0,0,0),Vec(pi*4,pi*4,pi*4)),
                        MarchingCubes(), samples=(50,50,50))
 
 save("gyroid.ply", gy_mesh)
@@ -54,7 +55,7 @@ save("gyroid.ply", gy_mesh)
 # view with Makie
 import Makie
 using LinearAlgebra
-Makie.mesh(gy_mesh, color=[norm(v) for v in gy_mesh.vertices])
+Makie.mesh(gy_mesh, color=[norm(v) for v in coordinates(gy_mesh)])
 ```
 
 ![gyroid](./img/gyroid.png)

--- a/src/geometrybasics_api.jl
+++ b/src/geometrybasics_api.jl
@@ -1,62 +1,39 @@
+function GB.Mesh(df::GT.SignedDistanceField{3,ST,FT},
+              method::AbstractMeshingAlgorithm;
+              pointtype=GB.Point{3,Float32},
+              facetype=GB.GLTriangleFace) where {ST, FT}
 
-"""
-    _determine_types_gb(meshtype, fieldtype=Float64, facelen=3)
-Given a subtype of AbstractMesh, determine the
-type of vertex/point and face to use for internal computations.
-Preference is given to the types specified by the Mesh call,
-and will default to the `FieldType` for `SignedDistanceField`,
-and Point{3,Float64}/TriangleFace{Int} for direct function sampling.
-"""
-function _determine_types_gb(pointtype, facetype, fieldtype=Float64, facelen=3)
-    # determine the point and face types
-    # preference is given to the Mesh types
-    # followed by SDF if unspecified
-    VertType = if pointtype isa Nothing
-        GB.Point{3, fieldtype}
-    else
-        pointtype
-    end
-
-    FaceType = if facetype isa Nothing
-        GB.NgonFace{facelen, Int}
-    else
-        facetype
-    end
-
-    return VertType, FaceType
-end
-
-function mesh(df::GT.SignedDistanceField{3,ST,FT}, method::AbstractMeshingAlgorithm;
-              pointtype=nothing, facetype=nothing, ) where {ST, FT}
-
-    vertex_eltype = promote_type(FT, typeof(method.iso), typeof(method.eps))
-    VertType, FaceType = _determine_types_gb(pointtype, facetype, vertex_eltype,
-                                          GB.default_face_length(method))
     h = df.bounds
-    vts, fcs = isosurface(df.data, method, VertType, FaceType, origin=VertType(GB.origin(h)), widths=VertType(GB.widths(h)))
-    return GB.Mesh(vts, fcs)
+    vts, fcs = isosurface(df.data, method, pointtype, facetype, origin=pointtype(GB.origin(h)), widths=pointtype(GB.widths(h)))
+    return GB.Mesh(GB.meta(vts), fcs)
 end
 
-function GB.mesh(f::Function, h::GB.Rect, samples::NTuple{3,T}, method::AbstractMeshingAlgorithm;
-              pointtype=nothing, facetype=nothing) where {T <: Integer}
-    vertex_eltype = promote_type(T, typeof(method.iso), typeof(method.eps))
-    VertType, FaceType = _determine_types_gb(pointtype, facetype, vertex_eltype,
-                                          default_face_length(method))
-    vts, fcs = isosurface(f, method, VertType, FaceType; samples=samples,
-                          origin=VertType(GB.origin(h)), widths=VertType(GB.widths(h)))
-    return GB.Mesh(vts, fcs)
+function GB.Mesh(f::Function,
+                 h::GB.Rect,
+                 samples::NTuple{3,T},
+                 method::AbstractMeshingAlgorithm;
+                 pointtype=GB.Point{3,Float32},
+                 facetype=GB.GLTriangleFace) where {T <: Integer}
+    vts, fcs = isosurface(f, method, pointtype, facetype; samples=samples,
+                          origin=pointtype(GB.origin(h)), widths=pointtype(GB.widths(h)))
+
+    return GB.Mesh(GB.meta(vts), fcs)
 end
 
-function GB.mesh(f::Function, h::GB.Rect, method::AbstractMeshingAlgorithm;
-              samples::NTuple{3,T}=_DEFAULT_SAMPLES, pointtype=nothing,
-              facetype=nothing) where {T <: Integer}
-    return mesh(f, h, samples, method; pointtype=pointtype, facetype=facetype)
+function GB.Mesh(f::Function, h::GB.Rect, method::AbstractMeshingAlgorithm;
+              samples::NTuple{3,T}=_DEFAULT_SAMPLES,
+              pointtype=GB.Point{3,Float32},
+              facetype=GB.GLTriangleFace) where {T <: Integer}
+
+    return GB.Mesh(f, h, samples, method; pointtype=pointtype, facetype=facetype)
 end
 
-function GB.mesh(volume::AbstractArray{T, 3}, method::AbstractMeshingAlgorithm; pointtype=nothing, facetype=nothing, kwargs...) where {T}
-    vertex_eltype = promote_type(T, typeof(method.iso), typeof(method.eps))
-    VertType, FaceType = _determine_types_gb(pointtype, facetype, vertex_eltype,
-                                          default_face_length(method))
-    vts, fcs = isosurface(volume, method, VertType, FaceType; kwargs...)
-    return GB.Mesh(vts, fcs)
+function GB.Mesh(volume::AbstractArray{T, 3},
+                 method::AbstractMeshingAlgorithm;
+                 pointtype=GB.Point{3,Float32},
+                 facetype=GB.GLTriangleFace,
+                 kwargs...) where {T}
+
+    vts, fcs = isosurface(volume, method, pointtype, facetype; kwargs...)
+    return GB.Mesh(GB.meta(vts), fcs)
 end

--- a/src/geometrybasics_api.jl
+++ b/src/geometrybasics_api.jl
@@ -5,7 +5,7 @@ function GB.Mesh(df::GT.SignedDistanceField{3,ST,FT},
 
     h = df.bounds
     vts, fcs = isosurface(df.data, method, pointtype, facetype, origin=pointtype(GB.origin(h)), widths=pointtype(GB.widths(h)))
-    return GB.Mesh(GB.meta(vts), fcs)
+    return GB.Mesh(vts, fcs)
 end
 
 function GB.Mesh(f::Function,
@@ -17,7 +17,7 @@ function GB.Mesh(f::Function,
     vts, fcs = isosurface(f, method, pointtype, facetype; samples=samples,
                           origin=pointtype(GB.origin(h)), widths=pointtype(GB.widths(h)))
 
-    return GB.Mesh(GB.meta(vts), fcs)
+    return GB.Mesh(vts, fcs)
 end
 
 function GB.Mesh(f::Function, h::GB.Rect, method::AbstractMeshingAlgorithm;
@@ -35,5 +35,5 @@ function GB.Mesh(volume::AbstractArray{T, 3},
                  kwargs...) where {T}
 
     vts, fcs = isosurface(volume, method, pointtype, facetype; kwargs...)
-    return GB.Mesh(GB.meta(vts), fcs)
+    return GB.Mesh(vts, fcs)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,11 +30,6 @@ end
     @test dt(HomogenousMesh{Point{3, Float64}, Face{3, UInt32}}) == (Point{3,Float64}, Face{3,UInt32})
     @test dt(HomogenousMesh{Point{3, Float32}, Face{3, UInt32}}, Float64) == (Point{3,Float32}, Face{3,UInt32})
     @test dt(HomogenousMesh, Float64, 4) == (Point{3,Float64}, Face{4,Int64})
-    dt = Meshing._determine_types_gb
-    @test dt(GB.Point3{Float64}, GB.TriangleFace{Int}) == (GB.Point{3,Float64}, GB.TriangleFace{Int64})
-    @test dt(GB.Point3f0, GB.GLTriangleFace) == (GB.Point3f0, GB.GLTriangleFace)
-    @test dt(nothing, nothing, Float16) == (GB.Point3{Float16}, GB.TriangleFace{Int64})
-    @test dt(nothing, nothing, Float64, 4) == (GB.Point{3,Float64}, GB.QuadFace{Int64})
 end
 
 @testset "surface nets" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -349,7 +349,7 @@ end
 @testset "GeometryBasics API" begin
     @testset "vararg passing" begin
         A = rand(20,20,20)
-        m = GB.mesh(A,MarchingTetrahedra(1.0),origin=Point(Float32(0),Float32(0),Float32(0)),widths=Point(Float32(1),Float32(1),Float32(1)))
+        m = GB.Mesh(A,MarchingTetrahedra(1.0),origin=Point(Float32(0),Float32(0),Float32(0)),widths=Point(Float32(1),Float32(1),Float32(1)))
         @test m isa GB.Mesh
     end
 end


### PR DESCRIPTION
Should close #72.

The key change is removing the promotion logic and default to GL primitives. The examples now work with Makie.