### PR TITLE
Bump compat for StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Meshing"
 uuid = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -10,7 +10,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 GeometryBasics = "0.2, 0.3, 0.4"
 GeometryTypes = "0.6,0.7,0.8"
-StaticArrays = "0.10,0.11,0.12, 1.0"
+StaticArrays = "0.10, 0.11, 0.12, 1.0, 1.1, 1.2"
 julia = "1.1"
 
 [extras]


### PR DESCRIPTION
Would be nice to bump include v1.1 and v1.2 of StaticArrays and tag a new patch release.