### PR TITLE
Fix index range for Marching Tetrahedra in isosurface

### DIFF
--- a/src/marching_tetrahedra.jl
+++ b/src/marching_tetrahedra.jl
@@ -186,7 +186,7 @@ function isosurface(f::Function, method::MarchingTetrahedra,
     zv = zero(eltype(VertType))
     vals = (zv,zv,zv,zv,zv,zv,zv,zv)
 
-    @inbounds for k = 1:nz, j = 1:ny, i = 1:nx
+    @inbounds for k = 1:nz-1, j = 1:ny-1, i = 1:nx-1
         points = (VertType(i-1,j-1,k-1).* scale .+ origin,
                   VertType(i-1,j  ,k-1).* scale .+ origin,
                   VertType(i  ,j  ,k-1).* scale .+ origin,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,16 +148,32 @@ end
 @testset "marching tetrahedra" begin
     a1 = MarchingTetrahedra()
     a2 = MarchingTetrahedra(reduceverts=false)
-    m1 = SimpleMesh(HyperRectangle(Vec(-1,-1,-1.),Vec(2,2,2.)), a1, samples=(21,21,21)) do v
-        sqrt(sum(dot(v,v))) - 1 # sphere
+    let
+        m1 = SimpleMesh(HyperRectangle(Vec(-1,-1,-1.),Vec(2,2,2.)), a1, samples=(21,21,21)) do v
+            sqrt(sum(dot(v,v))) - 1 # sphere
+        end
+        m2 = SimpleMesh(HyperRectangle(Vec(-1,-1,-1.),Vec(2,2,2.)), a2, samples=(21,21,21)) do v
+            sqrt(sum(dot(v,v))) - 1 # sphere
+        end
+        @test length(m1.vertices) == 5582
+        @test length(m2.vertices) == 33480
+        @test length(m1.faces) == 11160
+        @test length(m2.faces) == length(m1.faces)
     end
-    m2 = SimpleMesh(HyperRectangle(Vec(-1,-1,-1.),Vec(2,2,2.)), a2, samples=(21,21,21)) do v
-        sqrt(sum(dot(v,v))) - 1 # sphere
+
+    # When zero set is not completely within the box.
+    let
+        m1 = SimpleMesh(HyperRectangle(Vec(0,0,40), Vec(50,50,60)), a1, samples=(2,2,2)) do v
+            v[3] - 50 # Plane at z = 50.
+        end
+        m2 = SimpleMesh(HyperRectangle(Vec(0,0,40), Vec(50,50,60)), a2, samples=(2,2,2)) do v
+            v[3] - 50 # Plane at z = 50.
+        end
+        @test length(m1.vertices) == 9
+        @test length(m2.vertices) == 24
+        @test length(m1.faces) == 8
+        @test length(m2.faces) == length(m1.faces)
     end
-    @test length(m1.vertices) == 5582
-    @test length(m2.vertices) == 33480
-    @test length(m1.faces) == 11160
-    @test length(m2.faces) == length(m1.faces)
 end
 
 @testset "sign flips" begin


### PR DESCRIPTION
Thanks for making this library!

I am utilizing the MarchingTetrahedra (MT) algorithm in this library. In my specific use case, the zero-set of my isofunc is not entirely contained within the box domain. The resulting mesh has confusing borders and non-manifold vertices.

As an example, the following code tries to generate mesh for a square at $([0, 50], [0, 50], 50)$.
```Julia
using Meshing
using StaticArrays

a = isosurface(
    v->v[3]-50,
    MarchingTetrahedra();
    origin=SA[0,0,40], widths=SA[50,50,20], samples=(2,2,2)
)
```

I'm expecting it to generate 9 vertices and 8 triangles. Instead it generates 22 vertices and 32 triangles, some of them having weird connections.

<details>

```Julia
julia> a[1]
22-element Vector{SVector{3, Float64}}:
 [25.0, 25.0, 50.0]
 [50.0, 50.0, 50.0]
 [25.0, 50.0, 50.0]
 [25.0, 0.0, 50.0]
 [50.0, 25.0, 50.0]
 [50.0, 0.0, 50.0]
 [0.0, 25.0, 50.0]
 [0.0, 50.0, 50.0]
 [0.0, 0.0, 50.0]
 [75.0, 25.0, 50.0]
 [100.0, 50.0, 50.0]
 [75.0, 50.0, 50.0]
 [75.0, 0.0, 50.0]
 [100.0, 25.0, 50.0]
 [25.0, 75.0, 50.0]
 [50.0, 100.0, 50.0]
 [25.0, 100.0, 50.0]
 [50.0, 75.0, 50.0]
 [75.0, 75.0, 50.0]
 [100.0, 100.0, 50.0]
 [75.0, 100.0, 50.0]
 [100.0, 75.0, 50.0]

julia> a[2]
32-element Vector{SVector{3, Int64}}:
 [1, 2, 3]
 [4, 5, 1]
 [4, 6, 5]
 [1, 5, 2]
 [7, 3, 8]
 [7, 1, 3]
 [9, 4, 1]
 [7, 9, 1]
 [10, 11, 12]
 [13, 14, 10]
 [13, 8, 14]
 [10, 14, 11]
 [5, 12, 2]
 [5, 10, 12]
 [6, 13, 10]
 [5, 6, 10]
 [15, 16, 17]
 [3, 18, 15]
 [3, 2, 18]
 [15, 18, 16]
 [14, 17, 11]
 [14, 15, 17]
 [8, 3, 15]
 [14, 8, 15]
 [19, 20, 21]
 [12, 22, 19]
 [12, 11, 22]
 [19, 22, 20]
 [18, 21, 16]
 [18, 19, 21]
 [2, 12, 19]
 [18, 2, 19]
```

A lot of triangles are outside the range. An example of a confusing triangle is [13, 8, 14] where the coordinates are $(75,0,50)$, $(100,25,50)$ and $(0,50,0)$.

</details>

After analyzing the code, I found that the problem is that `isosurface` using MT will also sample one voxel beyond the specified range. Then, `vertId` function may incorrectly assign the same ID to some remote vertices, causing some of those vertices to be reduced.

Therefore, I propose the changes in this PR, which locally resolves my issue. The "minus one" in ending indices is also in accord with the `isosurface` function taking a signed distance field, as well as the `isosurface` function using Marching Cubes. New tests reflecting this are added as well.